### PR TITLE
Bug/145910321/reconfigure gulp auto installation setup

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,6 +37,30 @@ gulp.task('nodemon', () => {
     }
   });
 });
+gulp.task('angular', () => {
+  gulp.src('bower_components/angular/**/*.js')
+    .pipe(gulp.dest('public/lib/angular'));
+});
+gulp.task('bootstrap', () => {
+  gulp.src('bower_components/bootstrap/**/*')
+    .pipe(gulp.dest('public/lib/bootstrap'));
+});
+gulp.task('jquery', () => {
+  gulp.src('bower_components/juery/**/*')
+    .pipe(gulp.dest('public/lib/jquery'));
+});
+gulp.task('underscore', () => {
+  gulp.src('bower_components/underscore/**/*')
+    .pipe(gulp.dest('public/lib/underscore'));
+});
+gulp.task('angularUtils', () => {
+  gulp.src('bower_components/angular-ui-utils/modules/route/route.js')
+    .pipe(gulp.dest('public/lib/angular-ui-utils/modules'));
+});
+gulp.task('angular-bootstrap', () => {
+  gulp.src('bower_components/angular-bootstrap/**/*')
+    .pipe(gulp.dest('public/lib/angular-bootstrap'));
+});
 gulp.task('lint', () => {
   gulp.src(['public/js/**/*.js',
     'app/**/*.js',
@@ -47,12 +71,13 @@ gulp.task('lint', () => {
 });
 
 gulp.task('bower', () => {
-  bower().pipe(gulp.dest('./public/lib'));
+  bower().pipe(gulp.dest('./bower_components'));
 });
 
 gulp.task('test', ['mochaTest']);
 gulp.task('install', ['bower']);
-gulp.task('default', ['nodemon', 'watch', 'sass']);
+gulp.task('default', ['nodemon', 'watch', 'sass', 'angular', 'underscore',
+  'bootstrap', 'angular-bootstrap', 'angularUtils', 'jquery']);
 
 
 gulp.task('coveralls', () => {


### PR DESCRIPTION
### What does this PR do?

* It reconfigures gulp to install front end dependencies from the bower components to the public folder.

### Description of task?

* create gulp tasks for bower components i.e. angular, angular-ui-utils, bootstrap, underscore and jquery.

### How should this be tested?
* Run `npm install` to install all the dependencies
* After installation run `npm start` to start the application

### Any background context you want to provide?
* Not Available

### What are the relevant pivotal tracker stories?
* Installing bower components using gulp

### Screenshot
* When `npm install` is ran, all the components are successfully installed.
<img width="474" alt="screen shot 2017-05-23 at 1 17 48 pm" src="https://cloud.githubusercontent.com/assets/28448041/26354300/e923dab6-3fbb-11e7-8365-8a31c8c26cac.png">

* When `npm start` is performed
<img width="521" alt="screen shot 2017-05-23 at 1 12 47 pm" src="https://cloud.githubusercontent.com/assets/28448041/26354415/5e91b35e-3fbc-11e7-99d3-4390e10ca64d.png">


